### PR TITLE
Add script support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ Make sure your code passes the style linter! Check for mistakes and fix some of 
 npm run lint
 npm run lint:fix
 ```
+
+Run Mocha tests
+```
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2708,6 +2708,12 @@
         "glob": "^7.1.3"
       }
     },
+    "run-script-os": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.3.tgz",
+      "integrity": "sha512-xPlzE6533nvWVea5z7e5J7+JAIepfpxTu/HLGxcjJYlemVukOCWJBaRCod/DWXJFRIWEFOgSGbjd2m1QWTJi5w==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "scripts": {
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --fix --ext .js",
-    "dev": "export NODE_ENV=dev && npx nodemon server.js",
+    "dev": "run-script-os",
+    "dev:win32": "set NODE_ENV=dev && npx nodemon server.js",
+    "dev:default": "export NODE_ENV=dev && npx nodemon server.js",
     "start": "node server.js",
-    "test": "export NODE_ENV=test && mocha --timeout 10000 --exit"
+    "test":  "run-script-os",
+    "test:win32": "set NODE_ENV=test && mocha --timeout 10000 --exit",  
+    "test:default": "export NODE_ENV=test && mocha --timeout 10000 --exit"
   },
   "keywords": [],
   "author": "Jack Zhang",
@@ -32,6 +36,7 @@
     "mocha": "^8.2.1",
     "mocha-suppress-logs": "^0.2.0",
     "nodemon": "^2.0.2",
-    "prettier": "^2.1.2"
+    "prettier": "^2.1.2",
+    "run-script-os": "^1.1.3"
   }
 }


### PR DESCRIPTION
# Overview
Since `export var = something` is not valid on windows, add support for detecting windows OS and running `set var = something` instead.