### PR TITLE
Remove buggy run-scripts-os

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "mocha": "^8.2.1",
         "mocha-suppress-logs": "^0.2.0",
         "nodemon": "^2.0.2",
-        "prettier": "^2.1.2",
-        "run-script-os": "^1.1.3"
+        "prettier": "^2.1.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2689,12 +2688,6 @@
       "dependencies": {
         "glob": "^7.1.3"
       }
-    },
-    "node_modules/run-script-os": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.3.tgz",
-      "integrity": "sha512-xPlzE6533nvWVea5z7e5J7+JAIepfpxTu/HLGxcjJYlemVukOCWJBaRCod/DWXJFRIWEFOgSGbjd2m1QWTJi5w==",
-      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -6195,12 +6188,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "run-script-os": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.3.tgz",
-      "integrity": "sha512-xPlzE6533nvWVea5z7e5J7+JAIepfpxTu/HLGxcjJYlemVukOCWJBaRCod/DWXJFRIWEFOgSGbjd2m1QWTJi5w==",
-      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,13 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --fix --ext .js",
-    "dev": "run-script-os",
-    "dev:win32": "set NODE_ENV=dev && npx nodemon server.js",
-    "dev:default": "export NODE_ENV=dev && npx nodemon server.js",
-    "start": "node server.js",
-    "test":  "run-script-os",
-    "test:win32": "set NODE_ENV=test && mocha --timeout 10000 --exit",  
-    "test:default": "export NODE_ENV=test && mocha --timeout 10000 --exit"
+    "dev": "export NODE_ENV=dev && npx nodemon server.js",
+    "dev:win": "set NODE_ENV=dev && npx nodemon server.js",
+    "test": "export NODE_ENV=test && mocha --timeout 10000 --exit",
+    "test:win": "set NODE_ENV=test && mocha --timeout 10000 --exit"
   },
   "keywords": [],
   "author": "Jack Zhang",
@@ -36,7 +34,6 @@
     "mocha": "^8.2.1",
     "mocha-suppress-logs": "^0.2.0",
     "nodemon": "^2.0.2",
-    "prettier": "^2.1.2",
-    "run-script-os": "^1.1.3"
+    "prettier": "^2.1.2"
   }
 }


### PR DESCRIPTION
## Descriptions
The run-scripts-os package for running os-specific commands was buggy as hell, so we are removing it. Windows users will need to remember to `npm run dev:win` or `npm run test:win` in the future.