### PR TITLE
Fix locations not being deleted after each test

### DIFF
--- a/routes/bots.js
+++ b/routes/bots.js
@@ -109,13 +109,11 @@ botsRouter.route('/').post((req, res) => {
 			.json('Required name / lat / lon data not in request body.');
 	}
 
-	const newLocation = new Map.Location({
-		latitude: lat,
-		longitude: lon,
-	});
-
 	const newBot = new BruinBot({
-		location: newLocation,
+		location: {
+			latitude: lat,
+			longitude: lon,
+		},
 		status: 'Idle',
 		name: name,
 		inventory: [],

--- a/routes/bots.js
+++ b/routes/bots.js
@@ -3,7 +3,6 @@ const express = require('express');
 const botsRouter = express.Router();
 
 let { BruinBot, InventoryArticle } = require('../models/bruinbot.model');
-let Map = require('../models/map.model');
 let util = require('./utils');
 
 /**

--- a/routes/paths.js
+++ b/routes/paths.js
@@ -41,7 +41,6 @@ mapRouter.route('/').post(async (req, res) => {
 			return res.status(400).json({ error: 'Malformatted path coordinates.' });
 		}
 
-		const location = new Location({ latitude: lat, longitude: lon });
 		if (i === 0 || i === path.length - 1) {
 			// If a map node already exists for a location,
 			// use it instead of creating a new one.
@@ -49,9 +48,11 @@ mapRouter.route('/').post(async (req, res) => {
 				'location.latitude': lat,
 				'location.longitude': lon,
 			});
-			endPoints.push(existingNode || new MapNode({ location }));
+			endPoints.push(
+				existingNode || new MapNode({ latitude: lat, longitude: lon })
+			);
 		} else {
-			points.push(location);
+			points.push({ latitude: lat, longitude: lon });
 		}
 	}
 

--- a/routes/paths.js
+++ b/routes/paths.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 const mapRouter = express.Router();
 
-const { Location, MapNode, Path } = require('../models/map.model');
+const { MapNode, Path } = require('../models/map.model');
 
 /**
  * Get all map nodes.

--- a/test/utils.js
+++ b/test/utils.js
@@ -9,15 +9,11 @@ let { Location } = require('../models/map.model');
  * @returns {object} Saved bot in database
  */
 async function createAndSaveBot(bot) {
-	let newLocation = new Location({
-		latitude: bot.latitude,
-		longitude: bot.longitude,
-	});
-
-	await newLocation.save();
-
 	let newBot = new BruinBot({
-		location: newLocation,
+		location: {
+			latitude: bot.latitude,
+			longitude: bot.longitude,
+		},
 		status: 'Idle',
 		name: bot.name,
 		inventory: [],

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,4 @@
 let { BruinBot } = require('../models/bruinbot.model');
-let { Location } = require('../models/map.model');
 
 /**
  * Creates bot in memory and saves it to the test database


### PR DESCRIPTION
## Description
- Fix bot document creation so that paths are not saved as their own documents. In the future just do `location: { latitude: x, longitude: y }` instead of `let loc = new location(...); loc.save()`

## Notion
https://www.notion.so/uclabruinbot/Restructure-Locations-model-f7970aa20c81499ab2d46affaf9048db