### PR TITLE
Restrict deployment and reset CPU to required Fargate values

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -23,14 +23,14 @@
 #    See the documentation for each action used below for the recommended IAM policies for this IAM user,
 #    and best practices on handling the access key credentials.
 
-# on:
-#   release:
-#     types: [created]
-  
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [created]
+  
+# on:
+#   push:
+#     branches:
+#       - main
 
 name: Deploy to Amazon ECS
 

--- a/ecs-task-def.json
+++ b/ecs-task-def.json
@@ -62,7 +62,7 @@
     }
   ],
   "placementConstraints": [],
-  "memory": "256",
+  "memory": "512",
   "taskRoleArn": "arn:aws:iam::474608071686:role/ecsTaskExecutionRole",
   "family": "node-server-task",
   "pidMode": null,
@@ -70,7 +70,7 @@
     "FARGATE"
   ],
   "networkMode": "awsvpc",
-  "cpu": "64",
+  "cpu": "256",
   "inferenceAccelerators": null,
   "proxyConfiguration": null,
   "volumes": []


### PR DESCRIPTION
## Description
From now on, the server will be off while we are not supporting any actual users to reduce costs. Development should now be done locally. There will be no more deployment upon each merged PR; instead, when we are ready to deploy and serve users, we will create a release to trigger the deployment. The task can then be manually killed in the AWS console when the production server is no longer needed (e.g. during break, when there are no events, etc.)

Also, according to https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html, 512 memory and 256 CPU is the minimum for Fargate, so #45 's changes to the task definition will be reverted. 