### PR TITLE
Change prod env file dest

### DIFF
--- a/ecs-task-def.json
+++ b/ecs-task-def.json
@@ -6,7 +6,7 @@
       "dnsSearchDomains": null,
       "environmentFiles": [
         {
-          "value": "arn:aws:s3:::bruinbot-env/prod.env",
+          "value": "arn:aws:s3:::bruinbot-prod/prod.env",
           "type": "s3"
         }
       ],


### PR DESCRIPTION
## Description
- Updated the prod env file in AWS
- Changed location of production env file, removing the useless bruinbot-env directory and placing it in the bruinbot-prod directory which holds the rest of prod S3 files such as images

Had to edit IAM permissions on ecsTaskExecutionRole as follows: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html