### PR TITLE
Sale stats for bot

### DIFF
--- a/migrations/1609989986810-setup.js
+++ b/migrations/1609989986810-setup.js
@@ -38,12 +38,15 @@ async function up() {
 				longitude: -118.44476267506832,
 			},
 			inventory: [
-				{ item: item.id, quantity: 30 },
-				{ item: freeItem.id, quantity: 20 },
+				{
+					item: item.id,
+					quantity: 30,
+				},
+				{
+					item: freeItem.id,
+					quantity: 20,
+				},
 			],
-			sales: {
-				itemsSold: 0,
-			},
 		});
 
 		let bot2 = await BruinBot.create({
@@ -53,9 +56,6 @@ async function up() {
 				longitude: -118.4469310705838,
 			},
 			inventory: [],
-			sales: {
-				itemsSold: 0,
-			},
 		});
 
 		let event = await Event.create({

--- a/migrations/1609989986810-setup.js
+++ b/migrations/1609989986810-setup.js
@@ -41,6 +41,9 @@ async function up() {
 				{ item: item.id, quantity: 30 },
 				{ item: freeItem.id, quantity: 20 },
 			],
+			sales: {
+				itemsSold: 0,
+			},
 		});
 
 		let bot2 = await BruinBot.create({
@@ -50,6 +53,9 @@ async function up() {
 				longitude: -118.4469310705838,
 			},
 			inventory: [],
+			sales: {
+				itemsSold: 0,
+			},
 		});
 
 		let event = await Event.create({

--- a/migrations/1611980022385-sales.js
+++ b/migrations/1611980022385-sales.js
@@ -1,0 +1,43 @@
+let { BruinBot } = require('../models/bruinbot.model');
+
+/**
+ * Make any changes you need to make to the database here
+ */
+async function up() {
+	// Write migration here
+	if (process.env.NODE_ENV != 'production') {
+		let bots = await BruinBot.find();
+
+		bots.forEach(async (bot) => {
+			bot.inventory.forEach((article) => {
+				article.set({
+					sales: {
+						numSold: 0,
+					},
+				});
+			});
+
+			await bot.save();
+		});
+	}
+}
+
+/**
+ * Make any changes that UNDO the up function side effects here (if possible)
+ */
+async function down() {
+	// Write migration here
+	if (process.env.NODE_ENV != 'production') {
+		let bots = await BruinBot.find();
+
+		bots.forEach(async (bot) => {
+			bot.inventory.forEach((article) => {
+				article.sales = undefined;
+			});
+
+			await bot.save();
+		});
+	}
+}
+
+module.exports = { up, down };

--- a/models/bruinbot.model.js
+++ b/models/bruinbot.model.js
@@ -3,9 +3,9 @@ const map = require('./map.model.js');
 
 const schema = mongoose.Schema;
 
-// Sale statistics for a bot
+// Sale statistics for an inventory article (i.e. an item)
 const saleStats = new schema({
-	itemsSold: {
+	numSold: {
 		type: Number,
 		default: 0,
 	},
@@ -21,6 +21,9 @@ const inventoryArticle = new schema({
 	quantity: {
 		type: Number,
 		default: 0,
+	},
+	sales: {
+		type: saleStats,
 	},
 });
 
@@ -46,10 +49,6 @@ const bruinBotSchema = new schema({
 	},
 	inventory: {
 		type: [inventoryArticle],
-		required: true,
-	},
-	sales: {
-		type: saleStats,
 		required: true,
 	},
 });

--- a/models/bruinbot.model.js
+++ b/models/bruinbot.model.js
@@ -3,6 +3,14 @@ const map = require('./map.model.js');
 
 const schema = mongoose.Schema;
 
+// Sale statistics for a bot
+const saleStats = new schema({
+	itemsSold: {
+		type: Number,
+		default: 0,
+	},
+});
+
 // Represents an item and how many instances of it a bot holds
 const inventoryArticle = new schema({
 	item: {
@@ -40,9 +48,14 @@ const bruinBotSchema = new schema({
 		type: [inventoryArticle],
 		required: true,
 	},
+	sales: {
+		type: saleStats,
+		required: true,
+	},
 });
 
 const BruinBot = mongoose.model('BruinBot', bruinBotSchema);
 const InventoryArticle = mongoose.model('InventoryArticle', inventoryArticle);
+const SaleStats = mongoose.model('SaleStats', saleStats);
 
-module.exports = { BruinBot, InventoryArticle };
+module.exports = { BruinBot, InventoryArticle, SaleStats };

--- a/routes/bots.js
+++ b/routes/bots.js
@@ -112,6 +112,9 @@ botsRouter.route('/').post((req, res) => {
 		status: 'Idle',
 		name: name,
 		inventory: [],
+		sales: {
+			itemsSold: 0,
+		},
 	});
 
 	newBot.save(function (err) {
@@ -148,10 +151,15 @@ botsRouter.route('/addItem').post(async (req, res) => {
 			return res.status(404).json('Could not find bot specified by botId.');
 
 		let isNewInventoryItem = true;
+		let totalItemsSold = parseInt(bot.sales.itemsSold);
 
 		bot.inventory.forEach((article) => {
 			if (article.item == itemId) {
 				isNewInventoryItem = false;
+				// if quantity is less than 0, it indicates the item has been bought, so add it to bot's sale statistics
+				if (parseInt(quantity) < 0)
+					totalItemsSold += Math.abs(parseInt(quantity));
+
 				article.set({
 					quantity: parseInt(article.quantity) + parseInt(quantity),
 				});
@@ -166,6 +174,8 @@ botsRouter.route('/addItem').post(async (req, res) => {
 
 			bot.inventory.push(newInventoryArticle);
 		}
+
+		bot.sales.itemsSold = totalItemsSold;
 
 		await bot.save();
 		console.log('Added items to bot inventory: ', bot);

--- a/test/routes/utils.js
+++ b/test/routes/utils.js
@@ -21,6 +21,9 @@ async function createAndSaveBot(bot) {
 		status: 'Idle',
 		name: bot.name,
 		inventory: [],
+		sales: {
+			itemsSold: 0,
+		},
 	});
 
 	return await newBot.save();

--- a/test/routes/utils.js
+++ b/test/routes/utils.js
@@ -21,9 +21,6 @@ async function createAndSaveBot(bot) {
 		status: 'Idle',
 		name: bot.name,
 		inventory: [],
-		sales: {
-			itemsSold: 0,
-		},
 	});
 
 	return await newBot.save();


### PR DESCRIPTION
### **Changes**

- Added sale stats for bot
- Sale stats is an embedded object for each bot and the reason I chose to do a sales object instead of doing itemsSold is because we can add further attributes to the sales object like moneyMade, totalCustomers, etc. so in the future if we decided to add more sale stats it would be easier
- Modified POST bots/ to include sale stats when creating a bruin bot object
- Modified the POST bots/addItem to update sale stats only if quantity is less than 0 because that implies the item is being sold
- Modified the migrations file to include sales when creating a Bot 
- Modified the createAndSaveBot in test/routes/utils.js to include sales when creating a Bot

### **Requests**
![Screen Shot 2021-01-23 at 12 37 33 PM](https://user-images.githubusercontent.com/30224372/105613500-c7d44200-5d77-11eb-88fe-43d9f824f2b0.png)

### **Database with Sale Stats
<img width="352" alt="Screen Shot 2021-01-23 at 12 21 12 PM" src="https://user-images.githubusercontent.com/30224372/105613410-29e07780-5d77-11eb-8e71-8f1b982eb767.png">
### **Database with Sale Stats**
<img width="324" alt="Screen Shot 2021-01-23 at 12 21 25 PM" src="https://user-images.githubusercontent.com/30224372/105613407-28af4a80-5d77-11eb-9921-334b8fec8b28.png">
