### PR TITLE
Add websocket server and client

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,7 @@
 module.exports = {
 	// App constants
-	PORT: 8080,
+	EXPRESS_PORT: 8080,
+	WS_PORT: 8081,
 
 	// Hardware constants
 	BOT_SPEED: 0.5, // in m/s

--- a/package-lock.json
+++ b/package-lock.json
@@ -5890,6 +5890,11 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "ws": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
+    },
     "xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "mongoose": "^5.8.3",
     "multer": "^1.4.2",
     "multer-gridfs-storage": "^4.2.0",
-    "node-forge": "^0.10.0"
+    "node-forge": "^0.10.0",
+    "ws": "^7.4.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/routes/paths.js
+++ b/routes/paths.js
@@ -6,6 +6,8 @@ const { MapNode, Path } = require('../models/map.model');
 const { BOT_SPEED, VICINITY } = require('../constants');
 const { coordDistanceM } = require('../util/utils');
 
+const { wss } = require('../wss');
+
 /**
  * ----------------- GET (return information about objects) ----------------
  */
@@ -16,6 +18,9 @@ const { coordDistanceM } = require('../util/utils');
 mapRouter.route('/').get(async (req, res) => {
 	try {
 		const paths = await Path.find().populate('nodeA').populate('nodeB');
+		wss.clients.forEach((client) => {
+			client.send(JSON.stringify(paths));
+		});
 		res.json(paths);
 	} catch (err) {
 		console.log('Error: ' + err);

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const { app } = require('./app');
-const { wss } = require('./wss');
+const { wss, messageHandler } = require('./wss');
 const { EXPRESS_PORT } = require('./constants');
 
 const port = EXPRESS_PORT;
@@ -11,9 +11,9 @@ app.on('Mongoose ready', () => {
 	});
 
 	wss.on('connection', (ws) => {
-		ws.on('message', (message) => {
-			console.log('received: %s', message);
-			ws.send(`received: ${message}`);
+		ws.on('message', (msg) => {
+			messageHandler(msg);
+			ws.send(`received: ${msg}`);
 		});
 
 		ws.send('Welcome to BruinBot!');

--- a/server.js
+++ b/server.js
@@ -1,11 +1,21 @@
 const { app } = require('./app');
-const { PORT } = require('./constants');
+const { wss } = require('./wss');
+const { EXPRESS_PORT } = require('./constants');
 
-const port = PORT;
+const port = EXPRESS_PORT;
 const host = '0.0.0.0';
 
 app.on('Mongoose ready', () => {
 	app.listen(port, host, () => {
 		console.log(`The server is accepting connections from ${host}:${port}!\n`);
+	});
+
+	wss.on('connection', (ws) => {
+		ws.on('message', (message) => {
+			console.log('received: %s', message);
+			ws.send(`received: ${message}`);
+		});
+
+		ws.send('Welcome to BruinBot!');
 	});
 });

--- a/simulator/client.py
+++ b/simulator/client.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import asyncio
+import websockets
+
+async def connect_and_keep_alive():
+    uri = "ws://localhost:8081"
+    async with websockets.connect(uri) as websocket:
+        msg = "Hi! I'm Teddy Bear."
+        await websocket.send(msg)
+
+        res = await websocket.recv()
+        print(res)
+
+        while True:
+            res = await websocket.recv()
+            if res == "shutdown":
+                break
+            print(res)
+
+asyncio.get_event_loop().run_until_complete(connect_and_keep_alive())

--- a/wss.js
+++ b/wss.js
@@ -3,4 +3,9 @@ const { WS_PORT } = require('./constants');
 
 const wss = new WebSocket.Server({ port: WS_PORT });
 
+const messageHandler = (msg) => {
+	console.log(`received: ${msg}`);
+};
+
 module.exports.wss = wss;
+module.exports.messageHandler = messageHandler;

--- a/wss.js
+++ b/wss.js
@@ -1,0 +1,6 @@
+const WebSocket = require('ws');
+const { WS_PORT } = require('./constants');
+
+const wss = new WebSocket.Server({ port: WS_PORT });
+
+module.exports.wss = wss;


### PR DESCRIPTION
Changes:
1. Added a WebSocket server using package 'ws'. File wss.js is created where we can add some controls over the ws server. The ws server is serving on port 8081, and you can change the port in constants.js
2. Added a client script at /simulator/client.py. The server listens for messages from the server forever.
3. Added some codes under route GET /paths as an example as to how to send messages to the bots inside a route.

Note:
Has already tested that the connection is kept alive for several minutes. By theory, the connection should be opened forever until a shutdown message is sent to the client, but I haven't tested it for longer times. If the connection does have a timeout, we can add a TIMEOUT Exception handler that sends a heartbeat to the server.