### PR TITLE
Replace HTTP requests with pymongo operations

### DIFF
--- a/simulator/requirements.txt
+++ b/simulator/requirements.txt
@@ -19,3 +19,6 @@ virtualenv==20.1.0
 virtualenv-clone==0.5.4
 virtualenvwrapper==4.8.4
 Werkzeug==1.0.1
+pymongo==3.8.0
+dnspython
+python-dotenv==0.15.0


### PR DESCRIPTION
1. Removes Flask server from the simulator as it will not be used in the future.
2. In the simulator, replaces the use of the backend server's HTTP endpoints with pymongo operations to update and retrieve information stored in the MongoDB database.

Currently, the simulator is built to manage databases hosted locally; this can be changed.