### PR TITLE
Add waypoint queue to bot properties and endpoints

### DIFF
--- a/models/bruinbot.model.js
+++ b/models/bruinbot.model.js
@@ -41,6 +41,9 @@ const bruinBotSchema = new schema({
 	path: {
 		type: [map.Location.schema],
 	},
+	queue: {
+		type: [map.Location.schema],
+	},
 	name: {
 		type: String,
 		required: true,


### PR DESCRIPTION
Changes:

- Added array of queued waypoint nodes to bot database object; each queue member holds a Location object with coordinates
- Added endpoints for bots to GET waypoint queue of a bot and POST a wholly new queue to a bot