### PR TITLE
Send paths to bots

### DIFF
--- a/routes/paths.js
+++ b/routes/paths.js
@@ -6,7 +6,7 @@ const { MapNode, Path } = require('../models/map.model');
 const { BOT_SPEED, VICINITY } = require('../constants');
 const { coordDistanceM } = require('../util/utils');
 
-const { wss } = require('../wss');
+const { clients } = require('../wss');
 
 /**
  * ----------------- GET (return information about objects) ----------------
@@ -18,8 +18,11 @@ const { wss } = require('../wss');
 mapRouter.route('/').get(async (req, res) => {
 	try {
 		const paths = await Path.find().populate('nodeA').populate('nodeB');
-		wss.clients.forEach((client) => {
-			client.send(JSON.stringify(paths));
+		clients.forEach((client, key) => {
+			// Determine which client to send to by key
+			if (key === 'Teddy Bear') {
+				client.send(JSON.stringify(paths));
+			}
 		});
 		res.json(paths);
 	} catch (err) {

--- a/simulator/client.py
+++ b/simulator/client.py
@@ -7,7 +7,7 @@ async def connect_and_keep_alive():
     uri = "ws://localhost:8080/"
     timeout = 10
     async with websockets.connect(uri) as websocket:
-        msg = "Hi! I'm Teddy Bear."
+        msg = "register Teddy Bear"
         await websocket.send(msg)
 
         res = await websocket.recv()
@@ -21,6 +21,6 @@ async def connect_and_keep_alive():
                 print(res)
             except:
                 # Send request to ws server here...
-                await websocket.send("Timeout! Pinging from Teddy Bear...")
+                await websocket.send("path")
 
 asyncio.get_event_loop().run_until_complete(connect_and_keep_alive())

--- a/wss.js
+++ b/wss.js
@@ -45,26 +45,27 @@ const updateLocationHandler = async function (botId, lat, lon) {
 	}
 };
 
-const messageHandler = async (ws, msg) => {
+const messageHandler = async (msg, ws) => {
 	const msgSplit = msg.split(' ');
 	console.log(`received: ${msg}`);
 	if (msg.startsWith('register')) {
 		const key = msg.split('register')[1].substring(1);
 		clients.set(key, ws);
-		ws.send(`Welcome to BruinBot! ${key} is registered.`);
+		return `Welcome to BruinBot! ${key} is registered.`;
 	} else if (msg.startsWith('path')) {
 		const paths = await Path.find().populate('nodeA').populate('nodeB');
-		ws.send(JSON.stringify(paths));
+		return JSON.stringify(paths);
 	} else if (msgSplit[0] == 'location' && msgSplit.length == 4) {
 		updateLocationHandler(msgSplit[1], msgSplit[2], msgSplit[3]);
-		ws.send('Accepted and attempting location update request to database!');
-	} else if (msgSplit[0] == 'join') ws.send('Welcome to BruinBot!');
-	else ws.send('Error: WebSocket request not valid.');
+		return 'Accepted and attempting location update request to database!';
+	} else if (msgSplit[0] == 'join') return 'Welcome to BruinBot!';
+	else return 'Error: WebSocket request not valid.';
 };
 
 wss.on('connection', (ws) => {
-	ws.on('message', (msg) => {
-		messageHandler(ws, msg);
+	ws.on('message', async (msg) => {
+		const response = await messageHandler(msg, ws);
+		ws.send(response);
 	});
 	ws.on('close', () => {
 		clients.forEach((client, key) => {

--- a/wss.js
+++ b/wss.js
@@ -1,18 +1,50 @@
 const WebSocket = require('ws');
 
+const { Path } = require('./models/map.model');
+
 const wss = new WebSocket.Server({ noServer: true });
 
-const messageHandler = (msg) => {
+const clients = new Map();
+
+const commandBot = () => {
+	clients.forEach((client, key) => {
+		// Determine if we want to send command, who to send command to, and what to send
+		console.log('Sending command to bots...');
+		if (key === 'Teddy Bear') {
+			client.send('Pinging from server...');
+		}
+	});
+};
+
+const messageHandler = async (ws, msg) => {
 	console.log(`received: ${msg}`);
+	if (msg.startsWith('register')) {
+		const key = msg.split('register')[1].substring(1);
+		clients.set(key, ws);
+		ws.send(`Welcome to BruinBot! ${key} is registered.`);
+	} else if (msg.startsWith('path')) {
+		const paths = await Path.find().populate('nodeA').populate('nodeB');
+		ws.send(JSON.stringify(paths));
+	} else {
+		ws.send('Invalid request');
+	}
 };
 
 wss.on('connection', (ws) => {
 	ws.on('message', (msg) => {
-		messageHandler(msg);
-		ws.send(`received: ${msg}`);
+		messageHandler(ws, msg);
 	});
-
-	ws.send('Welcome to BruinBot!');
+	ws.on('close', () => {
+		clients.forEach((client, key) => {
+			if (ws === client) {
+				console.log(`${key} is disconnected.`);
+				clients.delete(key);
+			}
+		});
+	});
 });
 
+setInterval(commandBot, 10000);
+
 module.exports.wss = wss;
+module.exports.clients = clients;


### PR DESCRIPTION
Changes:
1. Bots can now make a request called "path" to get path.
2. Added key-value maps for bot clients so that now server can send information to a specific bot (when multiple bots with different keys are connected)
3. Server can also send command/info to bots without the bot making a request first. (This is done by using timeout and setInterval. It may not be the best solution, and I'm open to suggestions on how to do this better.)